### PR TITLE
Properly sort simulcast layers in example by size

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,9 +495,9 @@
 // Example of 3 spatial simulcast layers + 3 temporal layers with
 // an SSRC and RID for each simulcast layer
 var encodings = [
-  {rid: 'f', scalabilityMode: 'L1T3'},
-  {rid: 'h', scaleResolutionDownBy: 2.0, scalabilityMode: 'L1T3'},
   {rid: 'q', scaleResolutionDownBy: 4.0, scalabilityMode: 'L1T3'}
+  {rid: 'h', scaleResolutionDownBy: 2.0, scalabilityMode: 'L1T3'},
+  {rid: 'f', scalabilityMode: 'L1T3'},
 ];
 
 // Example of 3 spatial simulcast layers + 3 temporal layers on a single SSRC


### PR DESCRIPTION
Layers should be sorted by size, with the smaller ones first as they usually have a higher priority.