### PR TITLE
Add L1T1 scalability mode`

### DIFF
--- a/images/L1T1.svg
+++ b/images/L1T1.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" viewBox="0 0 880 280" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="sh">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="4"/>
+      <feOffset dx="2" dy="3"/>
+      <feBlend in="SourceGraphic"/>
+    </filter>
+  </defs>
+  <polygon points="865,245 856,242 856,248"/>
+  <line x1="60" y1="245" x2="865" y2="245" style="stroke:#000000;stroke-width:1"/>
+  <polygon points="60,12 57,21 63,21"/>
+  <line x1="60" y1="245" x2="60" y2="12" style="stroke:#000000;stroke-width:1"/>
+  <text x="830" y="267" font-family="Arial" font-size="20" style="white-space: pre;">Time<tspan x="155" y="267">0</tspan><tspan x="555" y="267">1</tspan><tspan x="2" y="20">Layer</tspan><tspan x="2" y="185">S0T0</tspan></text>
+  <rect x="80" y="130" width="160" height="90" style="fill:#cfe2f3;stroke-width:3;stroke:#000000" filter="url(#sh)"/>
+  <rect x="480" y="130" width="160" height="90" style="fill:#cfe2f3;stroke-width:3;stroke:#000000" filter="url(#sh)"/>
+  <polygon points="480,175 471,172 471,178"/>
+  <line x1="240" y1="175" x2="480" y2="175" style="stroke:#000000;stroke-width:1"/>
+  <polygon points="865,175 856,172 856,178"/>
+  <line x1="640" y1="175" x2="865" y2="175" style="stroke:#000000;stroke-width:1;stroke-dasharray:5,5"/>
+  <rect x="460" y="0" width="390" height="235" style="fill:none;stroke-width:2;stroke:#7f7f7f;stroke-dasharray:5,5"/>
+  <text x="462" y="22" font-family="Arial" font-size="20" style="white-space: pre;">Repeat</text>
+  <text style="white-space: pre; fill: rgb(51, 51, 51); font-family: Arial, sans-serif; font-size: 18.6px;" x="360.88" y="79.102"> </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -269,6 +269,14 @@
       </tbody>
       <tbody>
         <tr>
+          <td><a href="#L1T1*">"L1T1"</a></td>
+          <td>1</td>
+          <td></td>
+          <td>1</td>
+          <td></td>
+          <td>N/A</td>
+        </tr>
+        <tr>
           <td><a href="#L1T2*">"L1T2"</a></td>
           <td>1</td>
           <td></td>
@@ -885,6 +893,16 @@ let sendEncodings = [
   <section id="dependencydiagrams*">
    <h2>Scalability Mode Dependency Diagrams</h2>
    <p>Dependency diagrams for the scability modes defined in this specification are provided below.</p>
+   <section id="L1T1*">
+   <h3>L1T1</h3>
+          <figure>
+            <img alt="L1T1: a single layer" src=
+            "images/L1T1.svg" style="width:75%">
+            <figcaption>
+              L1T1: 1-layer encoding
+            </figcaption>
+          </figure>
+   </section>
    <section id="L1T2*">
    <h3>L1T2 and L1T2h</h3>
           <figure>

--- a/index.html
+++ b/index.html
@@ -151,8 +151,8 @@
         There are situations where a peer may only support reception of a subset
         of codecs and scalability modes. For example, an SFM that parses codec
         payloads may only support the H.264/AVC codec without scalability and
-        the H.264/SVC codec with temporal scalability. A browser that
-        can decode VP8 or VP9 may not support H.264/SVC or AV1.
+        the H.264/SVC codec with temporal scalability. A browser that can
+        decode any VP8 or VP9 scalability mode may not support H.264/SVC or AV1.
         In these situations, the {{RTCRtpReceiver}}'s <code>getCapabilities</code>
         method can be used to determine the scalability modes supported by the
         {{RTCRtpReceiver}}, and the {{RTCRtpSender}}'s <code>getCapabilities</code>

--- a/index.html
+++ b/index.html
@@ -252,7 +252,6 @@
      [[?RFC6190]], which supports both temporal and spatial scalability, only permits
      transport of simulcast on distinct SSRCs, so that it does not support the
      "S" modes, where multiple encodings are transported on a single RTP stream.</p>
-     
     <table class=simple>
       <tbody>
         <tr>

--- a/index.html
+++ b/index.html
@@ -221,7 +221,8 @@
               encoding of any scalability modes other than "L1T1", then the {{scalabilityModes}} member
               is not provided. The "L1T1" scalability mode is defined primarily for use with {{RTCRtpSender/setParameters()}},
               so as to enable scalable video coding to be turned off. "L1T1" SHOULD NOT be returned
-              within the sequence of scalability modes.</p>
+              within the sequence of scalability modes returned by {{RTCRtpSender}}<code>.getCapabilities()</code>,
+              or in response to {{RTCRtpSender/getParameters()}}.</p>
               <p>In response to a call to {{RTCRtpReceiver}}<code>.getCapabilities(<var>kind</var>)</code>,
               decoders that do not support decoding of scalability modes or that can
               decode any scalability mode (such as compliant VP8, VP9 and AV1 decoders)

--- a/index.html
+++ b/index.html
@@ -18,12 +18,9 @@
   <section class="informative" id="intro">
     <h2>Introduction</h2>
     <p>This specification extends the WebRTC specification [[WEBRTC]] to
-    enable configuration of encoding parameters for Scalable Video Coding (SVC). 
-    Since SVC bitstreams are self-describing and SVC-capable codecs implemented
-    in browsers require that compliant decoders be capable of decoding any
-    compliant encoding sent by an encoder, this specification does not support
-    decoder configuration. However, it is possible for decoders that cannot
-    decode any compliant bitstream to describe the supported scalability modes.</p>
+    enable configuration of encoding parameters for Scalable Video Coding (SVC).
+    While this specification does not support decoder configuration, it does enable
+    decoders to indicate supported scalability modes.</p> 
   </section>
   <section id="conformance">
     <p>This specification defines conformance criteria that apply to a single
@@ -80,10 +77,8 @@
     envelope negotiated by Offer/Answer."</p>
     <p>The configuration of SVC-capable codecs implemented in browsers fits within this
     restriction. Codecs such as VP8 [[?RFC6386]], VP9 [[?VP9]] and AV1 [[?AV1]] mandate support
-    for SVC and require a compliant decoder to be able to decode any compliant encoding
-    that an encoder can send. Therefore, for these codecs there is no need to
-    configure the decoder or to negotiate SVC support within Offer/Answer, enabling
-    encoding parameters to be used for SVC configuration.</p>
+    for scalable video coding tools. Therefore these codecs do not negotiate SVC support
+    within Offer/Answer, enabling encoding parameters to be used for SVC configuration.</p>
     <section id="error-handling">
       <h2>Error handling</h2>
       <p>
@@ -151,8 +146,8 @@
         There are situations where a peer may only support reception of a subset
         of codecs and scalability modes. For example, an SFM that parses codec
         payloads may only support the H.264/AVC codec without scalability and
-        the H.264/SVC codec with temporal scalability. A browser that can
-        decode any VP8 or VP9 scalability mode may not support H.264/SVC or AV1.
+        the H.264/SVC codec with temporal scalability. However, a browser that
+        can decode VP8 or VP9 may not support H.264/SVC or AV1.
         In these situations, the {{RTCRtpReceiver}}'s <code>getCapabilities</code>
         method can be used to determine the scalability modes supported by the
         {{RTCRtpReceiver}}, and the {{RTCRtpSender}}'s <code>getCapabilities</code>
@@ -213,16 +208,17 @@
           "RTCRtpCodecCapability" class="dictionary-members">
             <dt><dfn data-idl>scalabilityModes</dfn> of type <code>sequence&lt;{{DOMString}}&gt;</code></dt>
             <dd>
-              <p>An sequence of the scalability modes (defined in Section 6) supported by the encoder
+              <p>A sequence of the scalability modes (defined in Section 6) supported by the encoder
               implementation.</p>
               <p>In response to a call to {{RTCRtpSender}}<code>.getCapabilities(<var>kind</var>)</code>,
               conformant implementations of this specification MUST return a sequence of
               scalability modes supported by each codec of that <var>kind</var>.  If a codec does not support
-              encoding of any scalability modes, then the {{scalabilityModes}} member
-              is not provided.</p>
+              encoding of any scalability modes other than "L1T1", then the {{scalabilityModes}} member
+              is not provided. The "L1T1" scalability mode is defined primarily for use with {{RTCRtpSender/setParameters()}},
+              so as to enable scalable video coding to be turned off. "L1T1" SHOULD NOT be returned
+              within the sequence of scalability modes.</p>
               <p>In response to a call to {{RTCRtpReceiver}}<code>.getCapabilities(<var>kind</var>)</code>,
-              decoders that do not support decoding of scalability modes or that can
-              decode any scalability mode (such as compliant VP8, VP9 and AV1 decoders)
+              decoders that do not support decoding of scalability modes or that can decode any scalability mode
               omit the {{scalabilityModes}} member. However, decoders that only support
               decoding of a subset of scalability modes MUST return a sequence of the scalability
               modes supported by that codec.</p>
@@ -256,6 +252,7 @@
      [[?RFC6190]], which supports both temporal and spatial scalability, only permits
      transport of simulcast on distinct SSRCs, so that it does not support the
      "S" modes, where multiple encodings are transported on a single RTP stream.</p>
+     
     <table class=simple>
       <tbody>
         <tr>

--- a/index.html
+++ b/index.html
@@ -18,9 +18,12 @@
   <section class="informative" id="intro">
     <h2>Introduction</h2>
     <p>This specification extends the WebRTC specification [[WEBRTC]] to
-    enable configuration of encoding parameters for Scalable Video Coding (SVC).
-    While this specification does not support decoder configuration, it does enable
-    decoders to indicate supported scalability modes.</p> 
+    enable configuration of encoding parameters for Scalable Video Coding (SVC). 
+    Since SVC bitstreams are self-describing and SVC-capable codecs implemented
+    in browsers require that compliant decoders be capable of decoding any
+    compliant encoding sent by an encoder, this specification does not support
+    decoder configuration. However, it is possible for decoders that cannot
+    decode any compliant bitstream to describe the supported scalability modes.</p>
   </section>
   <section id="conformance">
     <p>This specification defines conformance criteria that apply to a single
@@ -77,8 +80,10 @@
     envelope negotiated by Offer/Answer."</p>
     <p>The configuration of SVC-capable codecs implemented in browsers fits within this
     restriction. Codecs such as VP8 [[?RFC6386]], VP9 [[?VP9]] and AV1 [[?AV1]] mandate support
-    for scalable video coding tools. Therefore these codecs do not negotiate SVC support
-    within Offer/Answer, enabling encoding parameters to be used for SVC configuration.</p>
+    for SVC and require a compliant decoder to be able to decode any compliant encoding
+    that an encoder can send. Therefore, for these codecs there is no need to
+    configure the decoder or to negotiate SVC support within Offer/Answer, enabling
+    encoding parameters to be used for SVC configuration.</p>
     <section id="error-handling">
       <h2>Error handling</h2>
       <p>

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         There are situations where a peer may only support reception of a subset
         of codecs and scalability modes. For example, an SFM that parses codec
         payloads may only support the H.264/AVC codec without scalability and
-        the H.264/SVC codec with temporal scalability. However, a browser that
+        the H.264/SVC codec with temporal scalability. A browser that
         can decode VP8 or VP9 may not support H.264/SVC or AV1.
         In these situations, the {{RTCRtpReceiver}}'s <code>getCapabilities</code>
         method can be used to determine the scalability modes supported by the
@@ -223,7 +223,8 @@
               so as to enable scalable video coding to be turned off. "L1T1" SHOULD NOT be returned
               within the sequence of scalability modes.</p>
               <p>In response to a call to {{RTCRtpReceiver}}<code>.getCapabilities(<var>kind</var>)</code>,
-              decoders that do not support decoding of scalability modes or that can decode any scalability mode
+              decoders that do not support decoding of scalability modes or that can
+              decode any scalability mode (such as compliant VP8, VP9 and AV1 decoders)
               omit the {{scalabilityModes}} member. However, decoders that only support
               decoding of a subset of scalability modes MUST return a sequence of the scalability
               modes supported by that codec.</p>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-svc/issues/48


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aboba/webrtc-svc/pull/51.html" title="Last updated on Nov 2, 2021, 11:39 PM UTC (c91a3bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/51/97965ed...aboba:c91a3bf.html" title="Last updated on Nov 2, 2021, 11:39 PM UTC (c91a3bf)">Diff</a>