### PR TITLE
Changing the interpretation if referenceScaling is absent

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,10 +180,10 @@
       <p>
         To determine what codecs and scalability modes an <a title="Selective Forwarding Middlebox">SFM</a> can send to the
         application, the application can utilize the [[?Media-Capabilities]] API.
-        If {{VideoConfiguration/referenceScaling}} is set to `false`, the decoder cannot decode
+        If {{VideoConfiguration/referenceScaling}} is set to `false` or is absent, the decoder cannot decode
         spatial scalability modes, but can decode all other 
         {{RTCRtpEncodingParameters/scalabilityMode}} values supported by the
-        encoder. If {{VideoConfiguration/referenceScaling}} is set to `true` or is absent, the
+        encoder. If {{VideoConfiguration/referenceScaling}} is set to `true` the
         decoder can decode any {{RTCRtpEncodingParameters/scalabilityMode}}
         value supported by the encoder.
       </p>


### PR DESCRIPTION
This PR changes the interpretation when `referenceScaling` is absent. 

Reflects discussion in Issue https://github.com/w3c/media-capabilities/issues/182

@chcunningham PTAL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/pull/56.html" title="Last updated on Dec 9, 2021, 3:29 AM UTC (87358e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/56/c437458...87358e4.html" title="Last updated on Dec 9, 2021, 3:29 AM UTC (87358e4)">Diff</a>