### PR TITLE
Clarify behavior of setParameters()

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,8 @@
          <p>
            [[!WEBRTC]] Section 5.2 describes validation of <var>parameters</var>
            within {{RTCRtpSender/setParameters()}}. Add the following to the 
-           conditions (step 4 within step 6) for an {{InvalidModificationError}}:
+           conditions under which the operation causes a promise rejected
+           with an {{InvalidModificationError}} (step 4 within step 6):
            <ol>
              <li>
                Before negotiation has concluded,

--- a/index.html
+++ b/index.html
@@ -218,11 +218,17 @@
            conditions (step 4 within step 6) for an {{InvalidModificationError}}:
            <ol>
              <li>
+               Before negotiation has concluded,
+               <var>sendEncodings</var> contains any encoding whose
+               {{RTCRtpEncodingParameters/scalabilityMode}} value is 
+               not supported by any codec in
+               {{RTCRtpSender.getCapabilities(kind)}}.<code>codecs</code>. 
+             </li>
+             <li>
+               After negotiation has concluded,
                <var>encodings</var> contains an encoding whose
                {{RTCRtpEncodingParameters/scalabilityMode}} value is
-               not supported by any codec in <var>codecs</var> (before
-               negotiation has completed) or by the most preferred codec
-               (after negotiation has completed).
+               not supported by the most preferred codec.
              </li>
              <li>
                <var>N</var> is greater than 1, and <var>encodings</var>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-svc/issues/66


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 26, 2022, 6:35 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Faboba%2Fwebrtc-svc%2Fe88234c2fc1991cc3bdf46b90fe4e3c6535763a7%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 29664 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-svc%2367.)._
</details>
