### PR TITLE
Clarify behavior of getParameters()

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,14 +219,14 @@
            with an {{InvalidModificationError}} (step 4 within step 6):
            <ol>
              <li>
-               Before negotiation has concluded,
+               Before initial negotiation has concluded,
                <var>encodings</var> contains any encoding whose
                {{RTCRtpEncodingParameters/scalabilityMode}} value is 
                not supported by any codec in
                {{RTCRtpSender.getCapabilities(kind)}}.<code>codecs</code>. 
              </li>
              <li>
-               After negotiation has concluded,
+               After initial negotiation has concluded,
                <var>encodings</var> contains an encoding whose
                {{RTCRtpEncodingParameters/scalabilityMode}} value is
                not supported by the most preferred codec.
@@ -243,14 +243,18 @@
       <section id="getparameters">
        <h3>{{RTCRtpSender/getParameters()}}</h3>
          <p>
-           Before the initial negotiation has completed, {{RTCRtpSender/getParameters()}}
-           returns the {{RTCRtpEncodingParameters/scalabilityMode}} value
-           for each encoding in <var>encodings</var>, as last set by
-           {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}.
-           If no {{RTCRtpEncodingParameters/scalabilityMode}} value was provided for
-           an encoding in <var>encodings</var>, or if a value was not successfully
-           set, then {{RTCRtpSender/getParameters()}} will not return a
-           {{RTCRtpEncodingParameters/scalabilityMode}} value for that encoding.
+           Before the initial negotiation has completed,
+           {{RTCRtpSender/getParameters()}} returns the
+           {{RTCRtpEncodingParameters/scalabilityMode}} value for each
+           encoding in <var>encodings</var>, as last set by
+           {{RTCPeerConnection/addTransceiver()}} or
+           {{RTCRtpSender/setParameters()}}. If no
+           {{RTCRtpEncodingParameters/scalabilityMode}} value
+           was provided for an encoding in <var>encodings</var>,
+           or if a value was not successfully set, then
+           {{RTCRtpSender/getParameters()}} will not return a
+           {{RTCRtpEncodingParameters/scalabilityMode}} value
+           for that encoding.
          </p>
          <p>
            After the initial negotiation has completed, {{RTCRtpSender/getParameters()}}

--- a/index.html
+++ b/index.html
@@ -243,9 +243,9 @@
       <section id="getparameters">
        <h3>{{RTCRtpSender/getParameters()}}</h3>
          <p>
-           Before negotiation has completed, {{RTCRtpSender/getParameters()}}
-           returns the {{RTCRtpEncodingParameters/scalabilityMode}} value for each
-           encoding in <var>encodings</var>, assuming it was successfully set by
+           Before the initial negotiation has completed, {{RTCRtpSender/getParameters()}}
+           returns the {{RTCRtpEncodingParameters/scalabilityMode}} value
+           for each encoding in <var>encodings</var>, as last set by
            {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}.
            If no {{RTCRtpEncodingParameters/scalabilityMode}} value was provided for
            an encoding in <var>encodings</var>, or if a value was not successfully
@@ -253,7 +253,7 @@
            {{RTCRtpEncodingParameters/scalabilityMode}} value for that encoding.
          </p>
          <p>
-           After negotiation has completed, {{RTCRtpSender/getParameters()}}
+           After the initial negotiation has completed, {{RTCRtpSender/getParameters()}}
            returns the currently configured {{RTCRtpEncodingParameters/scalabilityMode}}
            value for each encoding in <var>encodings</var>. This may be different
            from the values requested in {{RTCPeerConnection/addTransceiver()}}
@@ -263,15 +263,15 @@
          </p>
          <p>
            If {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}
-           did not provide an {{RTCRtpEncodingParameters/scalabilityMode}} value for        
-           an encoding in <var>encodings</var>, then after negotiation has completed,          
-           {{RTCRtpSender/getParameters()}} returns the default
+           did not provide an {{RTCRtpEncodingParameters/scalabilityMode}} value for    
+           an encoding in <var>encodings</var>, then after the initial negotiation
+           has completed, {{RTCRtpSender/getParameters()}} returns the default
            {{RTCRtpEncodingParameters/scalabilityMode}} of the most preferred codec
            for that encoding. The most preferred codec and the default
            {{RTCRtpEncodingParameters/scalabilityMode}} for each ecodec are both
-           implementation dependent. The default {{RTCRtpEncodingParameters/scalabilityMode}}
-           SHOULD be one of the temporal scalability modes
-           (e.g. [="L1T1"=],[="L1T2"=],[="L1T3"=], etc.).
+           implementation dependent. The default
+           {{RTCRtpEncodingParameters/scalabilityMode}} SHOULD be one of the
+           temporal scalability modes (e.g. [="L1T1"=],[="L1T2"=],[="L1T3"=], etc.).
          </p>  
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
            <ol>
              <li>
                Before negotiation has concluded,
-               <var>sendEncodings</var> contains any encoding whose
+               <var>encodings</var> contains any encoding whose
                {{RTCRtpEncodingParameters/scalabilityMode}} value is 
                not supported by any codec in
                {{RTCRtpSender.getCapabilities(kind)}}.<code>codecs</code>. 
@@ -244,11 +244,10 @@
        <h3>{{RTCRtpSender/getParameters()}}</h3>
          <p>
            Before negotiation has completed, {{RTCRtpSender/getParameters()}}
-           returns the {{RTCRtpEncodingParameters/scalabilityMode}} value for
-           each encoding in <var>encodings</var>, assuming it was successfully
-           set by {{RTCPeerConnection/addTransceiver()}}
-           or {{RTCRtpSender/setParameters()}}. If no 
-           {{RTCRtpEncodingParameters/scalabilityMode}} value was provided for
+           returns the {{RTCRtpEncodingParameters/scalabilityMode}} value for each
+           encoding in <var>encodings</var>, assuming it was successfully set by
+           {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}.
+           If no {{RTCRtpEncodingParameters/scalabilityMode}} value was provided for
            an encoding in <var>encodings</var>, or if a value was not successfully
            set, then {{RTCRtpSender/getParameters()}} will not return a
            {{RTCRtpEncodingParameters/scalabilityMode}} value for that encoding.
@@ -256,22 +255,23 @@
          <p>
            After negotiation has completed, {{RTCRtpSender/getParameters()}}
            returns the currently configured {{RTCRtpEncodingParameters/scalabilityMode}}
-           value for each encoding in <var>encodings</var>. This may be different from
-           the values requested in {{RTCPeerConnection/addTransceiver()}}
+           value for each encoding in <var>encodings</var>. This may be different
+           from the values requested in {{RTCPeerConnection/addTransceiver()}}
            or {{RTCRtpSender/setParameters()}}. If the configuration is
            not satisfactory, {{RTCRtpSender/setParameters()}} can be used
            to change it.
          </p>
          <p>
-           If an encoding in <var>encodings</var> had no
-           {{RTCRtpEncodingParameters/scalabilityMode}} value provided to
-           {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}},
+           If {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}
+           did not provide an {{RTCRtpEncodingParameters/scalabilityMode}} value for        
+           an encoding in <var>encodings</var>, then after negotiation has completed,          
            {{RTCRtpSender/getParameters()}} returns the default
-           {{RTCRtpEncodingParameters/scalabilityMode}} of the most preferred codec.
-           The most preferred codec and the default {{RTCRtpEncodingParameters/scalabilityMode}}
-           for each codec are both implementation dependent. The default
-           {{RTCRtpEncodingParameters/scalabilityMode}} SHOULD be one of the temporal
-           scalability modes (e.g. [="L1T1"=],[="L1T2"=],[="L1T3"=], etc.).
+           {{RTCRtpEncodingParameters/scalabilityMode}} of the most preferred codec
+           for that encoding. The most preferred codec and the default
+           {{RTCRtpEncodingParameters/scalabilityMode}} for each ecodec are both
+           implementation dependent. The default {{RTCRtpEncodingParameters/scalabilityMode}}
+           SHOULD be one of the temporal scalability modes
+           (e.g. [="L1T1"=],[="L1T2"=],[="L1T3"=], etc.).
          </p>  
       </section>
     </section>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-svc/issues/68

@alvestrand @murillo128 PTAL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 26, 2022, 7:16 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebrtc-svc%2F2d32a99999d5e478026f4e2405cdaa938b0e7827%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 29664 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-svc%2369.)._
</details>
