### PR TITLE
Remove references to L1T2h and L1T3h

### DIFF
--- a/index.html
+++ b/index.html
@@ -909,8 +909,8 @@ let sendEncodings = [
         "L1T1",
         "L1T2",
         "L1T3",
-        "L1T2h",
-        "L1T3h"
+        "L2T2h",
+        "L2T3h"
       ]
     },
     {
@@ -920,8 +920,8 @@ let sendEncodings = [
         "L1T1",
         "L1T2",
         "L1T3",
-        "L1T2h",
-        "L1T3h"
+        "L2T2h",
+        "L2T3h"
       ]
     }
 ]
@@ -988,22 +988,22 @@ let sendEncodings = [
           </figure>
    </section>
    <section id="L1T2*">
-   <h3>L1T2 and L1T2h</h3>
+   <h3>L1T2</h3>
           <figure>
-            <img alt="L1T2 and L1T2h: 2-layer temporal scalability encoding" src=
+            <img alt="L1T2: 2-layer temporal scalability encoding" src=
             "images/L1T2.svg" style="width:75%">
             <figcaption>
-              L1T2 and L1T2h: 1-layer spatial and 2-layer temporal scalability encoding
+              L1T2: 1-layer spatial and 2-layer temporal scalability encoding
             </figcaption>
           </figure>
    </section>
    <section id="L1T3*">
-   <h3>L1T3 and L1T3h</h3>
+   <h3>L1T3</h3>
           <figure>
-            <img alt="L1T3 and L1T3h: 3-layer temporal scalability encoding" src=
+            <img alt="L1T3: 3-layer temporal scalability encoding" src=
             "images/L1T3.svg" style="width:75%">
             <figcaption>
-              L1T3 and L1T3h: 1-layer spatial and 3-layer temporal scalability encoding
+              L1T3: 1-layer spatial and 3-layer temporal scalability encoding
             </figcaption>
           </figure>
    </section>


### PR DESCRIPTION
Those 2 modes don't exist, let's fix that copy-paste error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-svc/pull/71.html" title="Last updated on Aug 29, 2022, 8:09 PM UTC (3ad4ea9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/71/cc91cc7...Orphis:3ad4ea9.html" title="Last updated on Aug 29, 2022, 8:09 PM UTC (3ad4ea9)">Diff</a>