### PR TITLE
Update getParameters() to not return the default scalabilityMode

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
            After the initial negotiation has completed, {{RTCRtpSender/getParameters()}}
            returns the currently configured {{RTCRtpEncodingParameters/scalabilityMode}}
            value for each encoding in <var>encodings</var> which had a value before the
-           initial negotiation. This may be different from the values requested in
+           initial negotiation. This MAY be different from the values requested in
            {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}.
            For example, if the codecs selected during negotiation do not include an
            encoder supporting the desired {{RTCRtpEncodingParameters/scalabilityMode}}

--- a/index.html
+++ b/index.html
@@ -266,11 +266,11 @@
            returns the currently configured {{RTCRtpEncodingParameters/scalabilityMode}}
            value for each encoding in <var>encodings</var> which had a value before the
            initial negotation. This may be different from the values requested in
-           {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}},
-           for example when no encoder for the codecs selected after negotiation supports
-           the desired {{RTCRtpEncodingParameters/scalabilityMode}} value.
-           If the configuration is not satisfactory, {{RTCRtpSender/setParameters()}}
-           can be used to change it.
+           {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}.
+           For example, if the codecs selected during negotiation do not include an
+           encoder supporting the desired {{RTCRtpEncodingParameters/scalabilityMode}}
+           value, another value can be selected. If the configuration is not
+           satisfactory, {{RTCRtpSender/setParameters()}} can be used to change it.
          </p>
          <p>
            If {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}

--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
            After the initial negotiation has completed, {{RTCRtpSender/getParameters()}}
            returns the currently configured {{RTCRtpEncodingParameters/scalabilityMode}}
            value for each encoding in <var>encodings</var> which had a value before the
-           initial negotation. This may be different from the values requested in
+           initial negotiation. This may be different from the values requested in
            {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}.
            For example, if the codecs selected during negotiation do not include an
            encoder supporting the desired {{RTCRtpEncodingParameters/scalabilityMode}}

--- a/index.html
+++ b/index.html
@@ -264,20 +264,23 @@
          <p>
            After the initial negotiation has completed, {{RTCRtpSender/getParameters()}}
            returns the currently configured {{RTCRtpEncodingParameters/scalabilityMode}}
-           value for each encoding in <var>encodings</var>. This may be different
-           from the values requested in {{RTCPeerConnection/addTransceiver()}}
-           or {{RTCRtpSender/setParameters()}}. If the configuration is
-           not satisfactory, {{RTCRtpSender/setParameters()}} can be used
-           to change it.
+           value for each encoding in <var>encodings</var> which had a value before the
+           initial negotation. This may be different from the values requested in
+           {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}},
+           for example when no encoder for the codecs selected after negotiation supports
+           the desired {{RTCRtpEncodingParameters/scalabilityMode}} value.
+           If the configuration is not satisfactory, {{RTCRtpSender/setParameters()}}
+           can be used to change it.
          </p>
          <p>
            If {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}
-           did not provide an {{RTCRtpEncodingParameters/scalabilityMode}} value for    
+           did not provide a {{RTCRtpEncodingParameters/scalabilityMode}} value for    
            an encoding in <var>encodings</var>, then after the initial negotiation
-           has completed, {{RTCRtpSender/getParameters()}} returns the default
-           {{RTCRtpEncodingParameters/scalabilityMode}} of the most preferred codec
-           for that encoding. The most preferred codec and the default
-           {{RTCRtpEncodingParameters/scalabilityMode}} for each ecodec are both
+           has completed, {{RTCRtpSender/getParameters()}} will not return a
+           {{RTCRtpEncodingParameters/scalabilityMode}} value and the encoder will use
+           the default {{RTCRtpEncodingParameters/scalabilityMode}} of the most preferred
+           codec for that encoding. The most preferred codec and the default
+           {{RTCRtpEncodingParameters/scalabilityMode}} for each codec are both
            implementation dependent. The default
            {{RTCRtpEncodingParameters/scalabilityMode}} SHOULD be one of the
            temporal scalability modes (e.g. [="L1T1"=],[="L1T2"=],[="L1T3"=], etc.).

--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
            {{RTCPeerConnection/addTransceiver()}} or {{RTCRtpSender/setParameters()}}.
            For example, if the codecs selected during negotiation do not include an
            encoder supporting the desired {{RTCRtpEncodingParameters/scalabilityMode}}
-           value, another value can be selected. If the configuration is not
+           value, the user agent MAY select another value. If the configuration is not
            satisfactory, {{RTCRtpSender/setParameters()}} can be used to change it.
          </p>
          <p>


### PR DESCRIPTION
Always returning the current scalabilityMode has some backwards compatibility issues. Applications that need to select specific scalabilityModes will still be able to observe when a fallback happens, others could use getStats() instead.

Fixes #75


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-svc/pull/79.html" title="Last updated on Jan 26, 2023, 3:22 PM UTC (5e06ad2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/79/5196526...Orphis:5e06ad2.html" title="Last updated on Jan 26, 2023, 3:22 PM UTC (5e06ad2)">Diff</a>