### PR TITLE
Minor fix for simulcast with L1T3 sample code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -748,7 +748,7 @@ async function start() {
     pc.addTransceiver(stream.getVideoTracks()[0], {
       direction: 'sendonly',
       sendEncodings: [
-        {rid: 'q', scaleResolutionDownBy: 4.0, scalabilityMode: 'L1T3'}
+        {rid: 'q', scaleResolutionDownBy: 4.0, scalabilityMode: 'L1T3'},
         {rid: 'h', scaleResolutionDownBy: 2.0, scalabilityMode: 'L1T3'},
         {rid: 'f', scalabilityMode: 'L1T3'},
       ]    


### PR DESCRIPTION
Fix a minor sample code issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/taste1981/webrtc-svc/pull/85.html" title="Last updated on Feb 13, 2023, 5:54 AM UTC (eb927f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/85/860992d...taste1981:eb927f4.html" title="Last updated on Feb 13, 2023, 5:54 AM UTC (eb927f4)">Diff</a>