### PR TITLE
Refine error conditions for use of 'S' modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,11 +165,15 @@
                [= exception/throw =] an {{OperationError}}.
              </li>
              <li>
-               If the number of {{RTCRtpEncodingParameters}} stored in
-               <var>sendEncodings</var> is more than 1, and
+               If {{RTCRtpEncodingParameters}} stored in
+               <var>sendEncodings</var> contains more than 1
+               encoding with an {{RTCRtpEncodingParameters/active}}
+               member with a value of <code>true</code> and
                <var>sendEncodings</var> contains any encoding whose
                {{RTCRtpEncodingParameters/scalabilityMode}} value
-               represents an "S mode" [= exception/throw =] an
+               represents an "S mode" and whose
+               {{RTCRtpEncodingParameters/active}} member has a
+               value of <code>true</code>, [= exception/throw =] an
                {{OperationError}}.
              </li>
            </ol>
@@ -231,10 +235,15 @@
                not supported by the most preferred codec.
              </li>
              <li>
-               <var>N</var> is greater than 1, and <var>encodings</var>
-               contains an encoding whose
+               If {{RTCRtpEncodingParameters}} stored in
+               <var>encodings</var> contains more than 1
+               encoding with an {{RTCRtpEncodingParameters/active}}
+               member with a value of <code>true</code> and
+               <var>encodings</var> contains any encoding whose
                {{RTCRtpEncodingParameters/scalabilityMode}} value
-               represents an "S mode".
+               represents an "S mode" and whose
+               {{RTCRtpEncodingParameters/active}} member has a
+               value of <code>true</code>.
              </li>
            </ol>
          </p>


### PR DESCRIPTION
Fixes Issue https://github.com/w3c/webrtc-svc/issues/73


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/pull/86.html" title="Last updated on Feb 13, 2023, 6:43 AM UTC (37d1404)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/86/99882c7...37d1404.html" title="Last updated on Feb 13, 2023, 6:43 AM UTC (37d1404)">Diff</a>