### PR TITLE
Example: mixed codec simulcast + SVC

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,6 +801,16 @@ signaling.onmessage = async ({data: {description, candidate}}) => {
 let sendEncodings = [
   {scalabilityMode: 'L2T3'}
 ];
+          <p>
+             This is an example of mixed codec simulcast, with each simulcast layer having 3 temporal layers.
+          </p> 
+          </pre>
+          <pre class="example highlight">
+let sendEncodings = [
+        {rid: 'q', codec: {"clockRate": 90000, "mimeType": "video/AV1"}, scaleResolutionDownBy: 4.0, scalabilityMode: 'L1T3'},
+        {rid: 'h', codec: {"clockRate": 90000, "mimeType": "video/VP8"}, scaleResolutionDownBy: 2.0, scalabilityMode: 'L1T3'},
+        {rid: 'f', codec: {"clockRate": 90000, "mimeType": "video/VP8"}, scalabilityMode: 'L1T3'},
+];
           </pre>
           <p>
              This is an example with three spatial simulcast layers each with three temporal layers on a single SSRC.

--- a/index.html
+++ b/index.html
@@ -801,10 +801,10 @@ signaling.onmessage = async ({data: {description, candidate}}) => {
 let sendEncodings = [
   {scalabilityMode: 'L2T3'}
 ];
+          </pre>
           <p>
              This is an example of mixed codec simulcast, with each simulcast layer having 3 temporal layers.
           </p> 
-          </pre>
           <pre class="example highlight">
 let sendEncodings = [
         {rid: 'q', codec: {"clockRate": 90000, "mimeType": "video/AV1"}, scaleResolutionDownBy: 4.0, scalabilityMode: 'L1T3'},


### PR DESCRIPTION
Add a mixed codec simulcast + SVC example to go along with PR https://github.com/w3c/webrtc-svc/pull/89


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/pull/90.html" title="Last updated on Apr 15, 2023, 8:13 PM UTC (847c45f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/90/6b1fe0b...847c45f.html" title="Last updated on Apr 15, 2023, 8:13 PM UTC (847c45f)">Diff</a>