### PR TITLE
Remove reference to Media Capabilities from Terminology Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,10 +100,6 @@
         The term <dfn data-lt="SFM" data-noexport>Selective Forwarding Middlebox</dfn>
         (SFM) is defined in Section 3.7 of [[RFC7667]].
       </p>
-      <p>
-        <dfn data-noexport data-idl data-dfn-for="VideoConfiguration">spatialScalability</dfn>
-        is an addition to {{VideoConfiguration}} in the [[?Media-Capabilities]] API</a>.
-      </p>
   </section>
   <section id="configuration">
     <h2>Configuration</h2>


### PR DESCRIPTION
The terminology section currently has a reference to the Media Capabilities API, which appears to be resulting in MC being a normative reference, which it should not be.

Partial fix for #45


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/pull/96.html" title="Last updated on Dec 12, 2023, 11:00 PM UTC (bc56b27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/96/0fcba8a...bc56b27.html" title="Last updated on Dec 12, 2023, 11:00 PM UTC (bc56b27)">Diff</a>