### PR TITLE
Remove Discovery Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
               <p>
                 A case-sensitive identifier of the scalability mode to be
                 used for this stream. Scalability modes are defined in
-                Section 6.
+                Section 5.
               </p>
             </dd>
           </dl>
@@ -302,40 +302,25 @@
            temporal scalability modes (e.g. [="L1T1"=],[="L1T2"=],[="L1T3"=], etc.).
          </p>
       </section>
-    </section>
-  </section>
-  <section id="discovery" class="informative">
-    <h2>Discovery</h2>
-      <p>
-        The [[?Media-Capabilities]] API enables discovery of encoder and decoder
-        support for scalable video coding. {{VideoConfiguration//scalabilityMode}}
-        is used to query whether an encoder supports a particular
-        {{RTCRtpEncodingParameters/scalabilityMode}} value. The API indicates
-        whether the {{RTCRtpEncodingParameters/scalabilityMode}} value
-        is "supported", "smooth" and "power efficient".
-      </p>
-      <p>
-        The [[?Media-Capabilities]] API also provides information on decoder support
-        for spatial scalablity modes. {{VideoConfiguration/spatialScalability}}
-        indicates whether a decoder has the ability to support spatial prediction,
-        which requires the ability to use frames of a resolution different than
-        the current resolution as a dependency. If {{VideoConfiguration/spatialScalability}}
-        is set to <code>true</code>, the decoder can decode any
-        {{RTCRtpEncodingParameters/scalabilityMode}} value supported by the encoder.
-        If {{VideoConfiguration/spatialScalability}} is set to <code>false</code>
-        or is absent, the decoder cannot decode spatial scalability modes, but can
-        can decode all other {{RTCRtpEncodingParameters/scalabilityMode}} values
-        supported by the encoder.
-      </p>
       <section id="sfmnegotiation" class="informative">
-        <h2>Negotiation with an SFM</h2>
+        <h2>Negotiation Issues</h2>
           <p>
-            The <a title="Selective Forwarding Middlebox">SFM</a>
-            can provide information on the codecs and scalability modes it can
-            decode by providing its receiver capabilities.
-            After exchanging capabilities, the application can compute the
-            intersection of codecs and {{RTCRtpEncodingParameters/scalabilityMode}}
-            values supported by the browser's {{RTCRtpSender}} and the
+            SVC is most often employed in video conferencing, where a conferencing
+            server such as a <a title="Selective Forwarding Middlebox">SFM</a>
+            selectively forwards layers to participants based on their device
+            characteristics and available bandwidth. In such an environment,
+            the application will negotiate codecs to be sent and received with
+            the conferencing server. However, since scalability modes are not
+            negotiated in Offer/Answer, the application needs to determine
+            which scalability modes are available by other means.
+          </p>
+          <p>  
+            One way in which this can be achieved is for the SFM to provide
+            information on the codecs and scalability modes it can decode in
+            the form of receiver capabilities. After exchanging capabilities,
+            the application can compute the intersection of codecs and
+            {{RTCRtpEncodingParameters/scalabilityMode}} values supported
+            by the browser's {{RTCRtpSender}} and the
             <a title="Selective Forwarding Middlebox">SFM</a>'s receiver. This
             can be used to determine the arguments passed to the browser's
             {{RTCPeerConnection/addTransceiver()}} and {{RTCRtpSender/setParameters()}}
@@ -379,7 +364,8 @@
             <a title="Selective Forwarding Middlebox">SFM</a> may not be determined until
             completion of the Offer/Answer negotiation.
           </p>
-        </section>
+    </section>
+  </section>
   </section>
   <section id="scalabilitymodes*">
     <h3>Scalability modes</h3>
@@ -388,7 +374,7 @@
       as well as their associated identifiers and characteristics, are provided in the table
       below. The names of the {{RTCRtpEncodingParameters/scalabilityMode}} values (which are
       case sensitive) are provided, along with the scalability mode identifiers assigned in
-      [[?AV1]] Section 6.7.5, and links to dependency diagrams provided in Section 10.
+      [[?AV1]] Section 6.7.5, and links to dependency diagrams provided in Section 9.
     </p>
     <p>
       While the [[?AV1]] and VP9 [[?VP9]] specifications support all the
@@ -707,7 +693,7 @@
         <ol>
           <li>
             The proposed {{RTCRtpEncodingParameters/scalabilityMode}} MUST define entries to the table in
-            Section 6, including values for the Scalabilty Mode Identifier, spatial and
+            Section 5, including values for the Scalabilty Mode Identifier, spatial and
             temporal layers, Resolution Ratio, Inter-layer dependency and the corresponding
             AV1 scalability_mode_idc value (if assigned).
           </li>
@@ -727,7 +713,7 @@
             frames have their temporal identifier shifted upward.
           </li>
           <li>
-            A dependency diagram MUST be supplied, in the format provided in Section 10.
+            A dependency diagram MUST be supplied, in the format provided in Section 9.
           </li>
         </ol>
     </section>
@@ -939,6 +925,27 @@ try {
         {{RTCRtpEncodingParameters/scalabilityMode}} value
         is decodable for the codec in use can be obtained,
         which provides more information on hardware capabilities.
+      </p>
+      <p>
+        The [[?Media-Capabilities]] API enables discovery of encoder and decoder
+        support for scalable video coding. {{VideoConfiguration//scalabilityMode}}
+        is used to query whether an encoder supports a particular
+        {{RTCRtpEncodingParameters/scalabilityMode}} value. The API indicates
+        whether the {{RTCRtpEncodingParameters/scalabilityMode}} value
+        is "supported", "smooth" and "power efficient".
+      </p>
+      <p>
+        The [[?Media-Capabilities]] API also provides information on decoder support
+        for spatial scalablity modes. {{VideoConfiguration/spatialScalability}}
+        indicates whether a decoder has the ability to support spatial prediction,
+        which requires the ability to use frames of a resolution different than
+        the current resolution as a dependency. If {{VideoConfiguration/spatialScalability}}
+        is set to <code>true</code>, the decoder can decode any
+        {{RTCRtpEncodingParameters/scalabilityMode}} value supported by the encoder.
+        If {{VideoConfiguration/spatialScalability}} is set to <code>false</code>
+        or is absent, the decoder cannot decode spatial scalability modes, but can
+        can decode all other {{RTCRtpEncodingParameters/scalabilityMode}} values
+        supported by the encoder.
       </p>
       <p>
         As noted in [[?Media-Capabilities]] Section 3.1, the Media

--- a/index.html
+++ b/index.html
@@ -312,13 +312,14 @@
             the application will negotiate codecs to be sent and received with
             the conferencing server. However, since scalability modes are not
             negotiated in Offer/Answer, the application needs to determine
-            which scalability modes are available by other means.
+            which scalability modes the conference server supports by other
+            means.
           </p>
           <p>  
-            One way in which this can be achieved is for the SFM to provide
-            information on the codecs and scalability modes it can decode in
-            the form of receiver capabilities. After exchanging capabilities,
-            the application can compute the intersection of codecs and
+            One way to handle this is for the SFM to indicate the codecs
+            and scalability modes it can decode in the form of receiver
+            capabilities. After exchanging capabilities, the application
+            can compute the intersection of codecs and
             {{RTCRtpEncodingParameters/scalabilityMode}} values supported
             by the browser's {{RTCRtpSender}} and the
             <a title="Selective Forwarding Middlebox">SFM</a>'s receiver. This

--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
          </p>
       </section>
       <section id="sfmnegotiation" class="informative">
-        <h2>Negotiation Issues</h2>
+        <h2>Negotiation issues</h2>
           <p>
             SVC is most often employed in video conferencing, where a conferencing
             server such as a <a title="Selective Forwarding Middlebox">SFM</a>
@@ -347,7 +347,7 @@
             supported, and if so, what scalability modes the
             <a title="Selective Forwarding Middlebox">SFM</a> can handle. For example,
             an <a title="Selective Forwarding Middlebox">SFM</a> that can only support
-            reception of a maximum of 2 simulcast encodings on a single SSRC with the
+            reception of a maximum of two simulcast encodings on a single SSRC with the
             AV1 codec would only indicate support for the [="S2T1"=] and [="S2T1h"=] scalability
             modes in its receiver capabilities.
           </p>
@@ -929,10 +929,9 @@ try {
       <p>
         The [[?Media-Capabilities]] API enables discovery of encoder and decoder
         support for scalable video coding. {{VideoConfiguration//scalabilityMode}}
-        is used to query whether an encoder supports a particular
-        {{RTCRtpEncodingParameters/scalabilityMode}} value. The API indicates
-        whether the {{RTCRtpEncodingParameters/scalabilityMode}} value
-        is "supported", "smooth" and "power efficient".
+        is used to query whether an encoder supports a 
+        {{RTCRtpEncodingParameters/scalabilityMode}} value, indicating whether
+        it is "supported", "smooth" and "power efficient".
       </p>
       <p>
         The [[?Media-Capabilities]] API also provides information on decoder support
@@ -950,14 +949,8 @@ try {
       <p>
         As noted in [[?Media-Capabilities]] Section 3.1, the Media
         Capabilities API "will likely provide more accurate and
-        consistent information" than is available from the
-        WebRTC-SVC API. Media Capabilities provides information
-        on encoder and decoder capabilities, indicating whether
-        a proposed configuration (including a
-        {{RTCRtpEncodingParameters/scalabilityMode}} value) is
-        "supported", "smooth" and "power efficient".
-        [[?Media-Capabilities]] API also indicates whether the
-        decoder supports spatial prediction.  As noted in
+        consistent information" than is available from this
+        specification. As noted in 
         [[?Media-Capabilities]] Section 3.1, "This information is
         expected to have a high correlation with other information
         already available to the web pages as a given class of


### PR DESCRIPTION
Fixes #103 

Proposal: 
    1. Move Section 5.1 to Section 4.2.4. 
    2. Integrate material in Section 5 (Media Capabilities Discovery) with Section 7 Privacy Considerations and remove duplicate text.
    3. Renumber Sections.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aboba/webrtc-svc/pull/104.html" title="Last updated on May 9, 2024, 8:54 PM UTC (6e67b21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-svc/104/93da0ec...aboba:6e67b21.html" title="Last updated on May 9, 2024, 8:54 PM UTC (6e67b21)">Diff</a>