### PR TITLE
GitHub actions: replace ubuntu-20.04 with ubuntu-latest

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate-and-publish:
     name: Validate and Publish
-    runs-on: ubuntu-20.04 # only linux supported at present
+    runs-on: ubuntu-latest # only linux supported at present
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2 # use the action


### PR DESCRIPTION
[GitHub will no longer support the Ubuntu 20.04 runner image starting from April 1, 2025](https://github.com/actions/runner-images/issues/11101). That PR updates the actions to use ubuntu-latest instead